### PR TITLE
feat: 콤보 공격마다 디버그 로그 추가 (#77)

### DIFF
--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -52,6 +52,7 @@ public class PlayerAttack : MonoBehaviour
             StopCoroutine(_coDash);
 
         _comboStep = (_comboStep % 3) + 1;
+        Debug.Log($"공격{_comboStep}");
         _canCombo = false;
         _isAttacking = true;
         _animator.ResetTrigger("Attack");


### PR DESCRIPTION
## 개요

이슈 #77 구현 — 스페이스바로 발동되는 콤보 공격 단계마다 콘솔에 디버그 로그를 출력합니다.

## 변경 내용

`Assets/Scripts/Player/PlayerAttack.cs`의 `BasicAttack()`에서 `_comboStep` 값이 갱신된 직후 한 줄을 추가했습니다.

```csharp
_comboStep = (_comboStep % 3) + 1;
Debug.Log($"공격{_comboStep}");
```

## 동작

스페이스바로 공격할 때마다 콘솔에 다음과 같이 출력됩니다:

```
공격1
공격2
공격3
공격1
...
```

`_canCombo` 체크를 통과한 입력만 로그가 남으므로, 연타로 인한 무효 입력은 출력되지 않습니다.

## 완료 기준

- [x] 콤보 공격마다 로그 출력

Closes #77