### PR TITLE
fix(#81): PlayerAttack OnAttackEnd 상태 초기화 로직 개선

### DIFF
--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -52,7 +52,6 @@ public class PlayerAttack : MonoBehaviour
             StopCoroutine(_coDash);
 
         _comboStep = (_comboStep % 3) + 1;
-        Debug.Log($"공격{_comboStep}");
         _canCombo = false;
         _isAttacking = true;
         _animator.ResetTrigger("Attack");
@@ -74,8 +73,10 @@ public class PlayerAttack : MonoBehaviour
 
     public void OnAttackEnd()
     {
-        if (_comboStep == 0)
+        // 이미 ForceReset이 호출되었다면 추가 처리 불필요
+        if (!_isAttacking)
             return;
+
         ForceReset();
     }
 


### PR DESCRIPTION
## 🐛 이슈
PlayerAttack.OnAttackEnd()가 _comboStep == 0일 때 early return하기 때문에, 공격 중 피해를 입은 후 상태가 제대로 초기화되지 않습니다.

## 📋 변경 사항
- `_comboStep` 대신 `_isAttacking` 플래그로 중복 호출 방지
- 공격 중 피해를 입은 후에도 정상적으로 상태 초기화
- 애니메이션 이벤트 안전성 강화

## 🔍 상세 설명

### 문제 시나리오
1. 플레이어가 공격 중
2. 피해를 입음 → `PlayerStatus.OnDamage()`에서 `ForceReset()` 호출
3. `_comboStep`이 0으로 설정됨
4. 애니메이션이 종료되고 `OnAttackEnd()` 호출
5. `_comboStep == 0`이므로 early return → **상태 미초기화**
6. `_isAttacking`이 true로 유지되어 다음 공격 불가능

### 해결 방법
`_isAttacking` 플래그를 확인하여 이미 ForceReset이 호출되었는지 판단합니다.

```csharp
public void OnAttackEnd()
{
    // 이미 ForceReset이 호출되었다면 추가 처리 불필요
    if (!_isAttacking)
        return;

    ForceReset();
}
```

## ✅ 테스트 포인트
- [ ] 평상시 공격 → OnAttackEnd() 호출 확인
- [ ] 공격 중 피해 입음 → 피해 후에도 다음 공격 가능
- [ ] 콤보 완성 후 공격 종료 → 콤보 초기화 확인
- [ ] 공격 캔슬 후 바로 다른 행동 수행 → 정상 작동 확인

## 📚 관련 이슈
Closes #81