### PR TITLE
fix: ItemSlotList IndexOutOfRangeException 수정 (#83)

### DIFF
--- a/Assets/Scripts/UI/Inventory/ItemSlotList.cs
+++ b/Assets/Scripts/UI/Inventory/ItemSlotList.cs
@@ -66,7 +66,7 @@ public class ItemSlotList : MonoBehaviour
 
     public ItemData GetSelectedItem()
     {
-        if (selectedSlotIndex == -1)
+        if (selectedSlotIndex == -1 || selectedSlotIndex >= itemDataList.Count)
             return null;
         return itemDataList[selectedSlotIndex];
     }
@@ -85,9 +85,20 @@ public class ItemSlotList : MonoBehaviour
                 int capturedIndex = i;
                 slot.button.onClick.AddListener(() =>
                 {
-                    selectedSlotIndex = capturedIndex;
-                    itemInfo.SetItemData(itemDataList[capturedIndex]);
-                    Debug.Log($"선택된 슬롯: {selectedSlotIndex}");
+                    // 인덱스 범위 검증: 아이템이 제거되었을 수 있으므로 확인
+                    if (capturedIndex >= 0 && capturedIndex < itemDataList.Count)
+                    {
+                        selectedSlotIndex = capturedIndex;
+                        itemInfo.SetItemData(itemDataList[capturedIndex]);
+                        Debug.Log($"선택된 슬롯: {selectedSlotIndex}");
+                    }
+                    else
+                    {
+                        // 범위를 벗어난 경우 선택 초기화
+                        selectedSlotIndex = -1;
+                        itemInfo.SetEmpty();
+                        Debug.LogWarning($"선택된 슬롯 {capturedIndex}은 유효하지 않습니다.");
+                    }
                 });
 
                 slotList.Add(slot);


### PR DESCRIPTION
## 문제 설명
`ItemSlotList.UpdateSlots()`에서 동적으로 생성된 슬롯의 OnClick 리스너가 `capturedIndex`를 캡처하지만, 나중에 아이템이 제거되면 인덱스가 범위를 벗어날 수 있습니다.

## 해결 방법
### 1. onClick 리스너에 범위 검증 추가 (Line 85-99)
- `capturedIndex`가 `itemDataList.Count` 범위 내인지 확인
- 범위를 벗어날 경우 선택 초기화 및 경고 로그 출력

### 2. GetSelectedItem() 메서드에 범위 검증 추가 (Line 70)
- `selectedSlotIndex`가 유효한 범위인지 확인
- 범위를 벗어날 경우 null 반환

## 변경사항
```csharp
// OnClick 리스너 (85-99번 라인)
slot.button.onClick.AddListener(() =>
{
    // 인덱스 범위 검증: 아이템이 제거되었을 수 있으므로 확인
    if (capturedIndex >= 0 && capturedIndex < itemDataList.Count)
    {
        selectedSlotIndex = capturedIndex;
        itemInfo.SetItemData(itemDataList[capturedIndex]);
        Debug.Log($"선택된 슬롯: {selectedSlotIndex}");
    }
    else
    {
        // 범위를 벗어난 경우 선택 초기화
        selectedSlotIndex = -1;
        itemInfo.SetEmpty();
        Debug.LogWarning($"선택된 슬롯 {capturedIndex}은 유효하지 않습니다.");
    }
});

// GetSelectedItem() 메서드 (70번 라인)
public ItemData GetSelectedItem()
{
    if (selectedSlotIndex == -1 || selectedSlotIndex >= itemDataList.Count)
        return null;
    return itemDataList[selectedSlotIndex];
}
```

## 테스트 시나리오
1. 아이템 5개 추가 (슬롯 0-4 생성)
2. 슬롯 4 클릭 (capturedIndex = 4 저장)
3. 인벤토리에서 아이템 3개 제거
4. 슬롯 4 클릭 → **IndexOutOfRangeException 발생 안 함** ✅

## 관련 이슈
Closes #83