### PR TITLE
fix: BaseMonster alertMarkPrefab null 체크 누락 수정 (#82)

### DIFF
--- a/Assets/Scripts/Monster/BaseMonster.cs
+++ b/Assets/Scripts/Monster/BaseMonster.cs
@@ -144,7 +144,8 @@ public abstract class BaseMonster : LivingEntity
             }
         }
 
-        alertMarkPrefab.SetActive(false);
+        if (alertMarkPrefab != null)
+            alertMarkPrefab.SetActive(false);
         ChangeState(MonsterState.Idle, true);
     }
 
@@ -218,7 +219,8 @@ public abstract class BaseMonster : LivingEntity
         {
             case MonsterState.Idle:
                 StopMoving();
-                alertMarkPrefab.SetActive(false);
+                if (alertMarkPrefab != null)
+                    alertMarkPrefab.SetActive(false);
                 PlayIdleAnim();
                 break;
 
@@ -239,13 +241,15 @@ public abstract class BaseMonster : LivingEntity
                 break;
 
             case MonsterState.Return:
-                alertMarkPrefab.SetActive(false);
+                if (alertMarkPrefab != null)
+                    alertMarkPrefab.SetActive(false);
                 ResumeMoving();
                 break;
 
             case MonsterState.Dead:
                 StopMoving();
-                alertMarkPrefab.SetActive(false);
+                if (alertMarkPrefab != null)
+                    alertMarkPrefab.SetActive(false);
 
                 if (bodyCollider != null)
                 {
@@ -475,7 +479,8 @@ public abstract class BaseMonster : LivingEntity
             return;
         }
 
-        alertMarkPrefab.SetActive(false);
+        if (alertMarkPrefab != null)
+            alertMarkPrefab.SetActive(false);
 
         float dist = GetDistanceToPlayer();
 


### PR DESCRIPTION
## 개요

`BaseMonster.cs`에서 `alertMarkPrefab`을 null 체크 없이 사용하는 위치가 있어 Inspector에서 미할당 시 `NullReferenceException`이 발생하던 문제를 수정합니다.

Closes #82

## 변경 내용

`alertMarkPrefab.SetActive(false)` 호출 전 null 체크가 누락된 5곳에 가드 추가:

| 위치 | 메서드 |
|------|--------|
| `OnEnable()` | 초기화 시 비활성화 |
| `EnterState()` — Idle | Idle 상태 진입 시 |
| `EnterState()` — Return | Return 상태 진입 시 |
| `EnterState()` — Dead | Dead 상태 진입 시 |
| `HandleDamageAggro()` | 피격 어그로 처리 시 |

기존 `ShowAlertMark()`의 null 체크 패턴과 동일하게 통일하여 일관성 확보.

## 리뷰어 참고사항

- `alertMarkPrefab`을 Inspector에서 할당하지 않아도 크래시 없이 동작
- 기존 동작(할당된 경우)은 변경 없음