### PR TITLE
feat: 마우스 우클릭 점프 기능 추가 (#93)

### DIFF
--- a/Assets/Scripts/Player/PlayerInput.cs
+++ b/Assets/Scripts/Player/PlayerInput.cs
@@ -10,6 +10,7 @@ public class PlayerInput : MonoBehaviour
     public Vector2 MousePosition { get; private set; }
     public bool Fire { get; private set; }
     public bool Attack { get; private set; }
+    public bool Jump { get; private set; }
     public bool SkillQ { get; private set; }
     public bool SkillW { get; private set; }
     public bool SkillE { get; private set; }
@@ -24,6 +25,7 @@ public class PlayerInput : MonoBehaviour
         MoveY = Input.GetAxisRaw(MoveYAxis);
         MousePosition = Input.mousePosition;
         Attack = Input.GetKeyDown(KeyCode.Space);
+        Jump = Input.GetMouseButtonDown(1);
         SkillQ = Input.GetKeyDown(KeyCode.Q);
         SkillW = Input.GetKeyDown(KeyCode.W);
         SkillE = Input.GetKeyDown(KeyCode.E);

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -11,10 +11,28 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField]
     private float _animAcceleration = 2f; // 증가 속도
 
+    [Header("점프")]
+    [SerializeField]
+    private float _jumpVelocity = 7f;
+
+    [SerializeField]
+    private float _gravity = -20f;
+
+    [SerializeField]
+    private float _groundCheckDistance = 0.2f;
+
+    [SerializeField]
+    private float _groundCheckOriginOffset = 0.1f;
+
+    [SerializeField]
+    private LayerMask _groundLayer = ~0;
+
     private Vector3 _playerDirection;
     public Vector3 PlayerDirection => _playerDirection;
 
     private float _currentSpeed = 0f;
+    private float _verticalVelocity = 0f;
+    private bool _wantsJump = false;
 
     private PlayerInput _playerInput;
     private PlayerAttack _playerAttack;
@@ -37,6 +55,10 @@ public class PlayerMovement : MonoBehaviour
     {
         _playerDirection = new Vector3(_playerInput.MoveX, 0f, _playerInput.MoveY).normalized;
         Rotate();
+
+        // 점프 입력은 Update에서 캡처 (GetMouseButtonDown은 프레임 단위)
+        if (_playerInput.Jump && CanJump())
+            _wantsJump = true;
     }
 
     private void FixedUpdate()
@@ -46,28 +68,49 @@ public class PlayerMovement : MonoBehaviour
 
     private void Move()
     {
-        if (
-            _playerAttack.IsAttacking
-            || _playerSkill.IsUsingSkill
-            || _playerStatus.IsHit
-            || _playerStatus.IsDead
-        )
+        bool canControl =
+            !_playerAttack.IsAttacking
+            && !_playerSkill.IsUsingSkill
+            && !_playerStatus.IsHit
+            && !_playerStatus.IsDead;
+
+        // 수평 이동
+        Vector3 horizontalDelta = Vector3.zero;
+        if (canControl)
+        {
+            horizontalDelta = _playerDirection * _moveSpeed * Time.fixedDeltaTime;
+
+            float targetSpeed = _playerDirection.magnitude;
+            _currentSpeed = Mathf.MoveTowards(
+                _currentSpeed,
+                targetSpeed,
+                _animAcceleration * Time.fixedDeltaTime
+            );
+            _playerAnimator.SetFloat("Speed", _currentSpeed);
+        }
+        else
         {
             _playerAnimator.SetFloat("Speed", 0f);
-            return;
         }
 
-        _playerRigidbody.MovePosition(
-            _playerRigidbody.position + _playerDirection * _moveSpeed * Time.fixedDeltaTime
-        );
+        // 수직 이동 (중력 + 점프)
+        bool grounded = IsGrounded();
+        if (_wantsJump)
+        {
+            _verticalVelocity = _jumpVelocity;
+            _wantsJump = false;
+        }
+        else if (grounded && _verticalVelocity <= 0f)
+        {
+            _verticalVelocity = -2f; // 지면 밀착용 소량 하향 속도
+        }
+        else
+        {
+            _verticalVelocity += _gravity * Time.fixedDeltaTime;
+        }
 
-        float targetSpeed = _playerDirection.magnitude;
-        _currentSpeed = Mathf.MoveTowards(
-            _currentSpeed,
-            targetSpeed,
-            _animAcceleration * Time.fixedDeltaTime
-        );
-        _playerAnimator.SetFloat("Speed", _currentSpeed);
+        Vector3 verticalDelta = Vector3.up * _verticalVelocity * Time.fixedDeltaTime;
+        _playerRigidbody.MovePosition(_playerRigidbody.position + horizontalDelta + verticalDelta);
     }
 
     private void Rotate()
@@ -88,6 +131,31 @@ public class PlayerMovement : MonoBehaviour
             transform.rotation,
             Quaternion.LookRotation(direction),
             _rotateSpeed * Time.deltaTime
+        );
+    }
+
+    private bool CanJump()
+    {
+        if (
+            _playerAttack.IsAttacking
+            || _playerSkill.IsUsingSkill
+            || _playerStatus.IsHit
+            || _playerStatus.IsDead
+        )
+            return false;
+
+        return IsGrounded();
+    }
+
+    private bool IsGrounded()
+    {
+        Vector3 origin = _playerRigidbody.position + Vector3.up * _groundCheckOriginOffset;
+        return Physics.Raycast(
+            origin,
+            Vector3.down,
+            _groundCheckOriginOffset + _groundCheckDistance,
+            _groundLayer,
+            QueryTriggerInteraction.Ignore
         );
     }
 }


### PR DESCRIPTION
## 개요

이슈 #93 구현 — 마우스 오른쪽 버튼으로 플레이어가 점프합니다.

## 변경 내용

### `PlayerInput.cs`
- `Jump` 속성 추가 (`Input.GetMouseButtonDown(1)`)

### `PlayerMovement.cs`
- 점프/지면 체크 로직 통합
- SerializeField로 노출된 파라미터(Inspector에서 조정 가능):
  - `_jumpVelocity` (기본 7) — 점프 초기 속도
  - `_gravity` (기본 -20) — 중력 가속도
  - `_groundCheckDistance` (기본 0.2) — 지면 Raycast 거리
  - `_groundCheckOriginOffset` (기본 0.1) — Raycast 시작점 오프셋
  - `_groundLayer` — 지면 레이어 마스크
- `IsGrounded()` — `Vector3.down` 방향 Raycast로 지면 판정
- `CanJump()` — 지면에 있고 공격/스킬/피격/사망 상태가 아닐 때만 `true`
- `Move()`가 수평 + 수직 변위를 합쳐 한 번의 `MovePosition` 호출로 적용 (기존 수평 전용 MovePosition이 점프 임펄스를 덮어쓰는 문제 회피)

## 동작 사양

- 마우스 오른쪽 버튼 클릭 → 지면에 있고 액션 중이 아니면 점프
- 공중에서는 중력으로 자연 낙하
- 공격/스킬/피격/사망 상태에서는 점프 불가
- 더블 점프 없음

## 완료 기준

- [x] 마우스 오른쪽 버튼으로 점프

Closes #93